### PR TITLE
Fix- pH cleaning code moved

### DIFF
--- a/CIS2004_Dataset_Explore_Isabella_Rios.ipynb
+++ b/CIS2004_Dataset_Explore_Isabella_Rios.ipynb
@@ -2,7 +2,7 @@
   "cells": [
     {
       "cell_type": "code",
-      "execution_count": 11,
+      "execution_count": 23,
       "metadata": {
         "id": "gr_NG--xDWly"
       },
@@ -13,19 +13,19 @@
           "text": [
             "Requirement already satisfied: pandas in /usr/local/python/3.12.1/lib/python3.12/site-packages (3.0.1)\n",
             "Requirement already satisfied: matplotlib in /usr/local/python/3.12.1/lib/python3.12/site-packages (3.10.8)\n",
-            "Requirement already satisfied: numpy>=1.26.0 in /usr/local/python/3.12.1/lib/python3.12/site-packages (from pandas) (2.4.2)\n",
+            "Requirement already satisfied: numpy>=1.26.0 in /usr/local/python/3.12.1/lib/python3.12/site-packages (from pandas) (2.4.3)\n",
             "Requirement already satisfied: python-dateutil>=2.8.2 in /home/codespace/.local/lib/python3.12/site-packages (from pandas) (2.9.0.post0)\n",
             "Requirement already satisfied: contourpy>=1.0.1 in /usr/local/python/3.12.1/lib/python3.12/site-packages (from matplotlib) (1.3.3)\n",
             "Requirement already satisfied: cycler>=0.10 in /usr/local/python/3.12.1/lib/python3.12/site-packages (from matplotlib) (0.12.1)\n",
-            "Requirement already satisfied: fonttools>=4.22.0 in /usr/local/python/3.12.1/lib/python3.12/site-packages (from matplotlib) (4.61.1)\n",
-            "Requirement already satisfied: kiwisolver>=1.3.1 in /usr/local/python/3.12.1/lib/python3.12/site-packages (from matplotlib) (1.4.9)\n",
+            "Requirement already satisfied: fonttools>=4.22.0 in /usr/local/python/3.12.1/lib/python3.12/site-packages (from matplotlib) (4.62.1)\n",
+            "Requirement already satisfied: kiwisolver>=1.3.1 in /usr/local/python/3.12.1/lib/python3.12/site-packages (from matplotlib) (1.5.0)\n",
             "Requirement already satisfied: packaging>=20.0 in /home/codespace/.local/lib/python3.12/site-packages (from matplotlib) (25.0)\n",
             "Requirement already satisfied: pillow>=8 in /usr/local/python/3.12.1/lib/python3.12/site-packages (from matplotlib) (12.1.1)\n",
             "Requirement already satisfied: pyparsing>=3 in /usr/local/python/3.12.1/lib/python3.12/site-packages (from matplotlib) (3.3.2)\n",
             "Requirement already satisfied: six>=1.5 in /home/codespace/.local/lib/python3.12/site-packages (from python-dateutil>=2.8.2->pandas) (1.17.0)\n",
             "\n",
             "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m25.3\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m26.0.1\u001b[0m\n",
-            "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpython -m pip install --upgrade pip\u001b[0m\n",
+            "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
             "Note: you may need to restart the kernel to use updated packages.\n"
           ]
         }
@@ -41,7 +41,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": 24,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -226,7 +226,7 @@
               "4         NaN          0.0  1994  "
             ]
           },
-          "execution_count": 12,
+          "execution_count": 24,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -237,7 +237,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
+      "execution_count": 25,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -260,7 +260,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 14,
+      "execution_count": 26,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -288,7 +288,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 15,
+      "execution_count": 27,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -328,7 +328,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 16,
+      "execution_count": 28,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -368,47 +368,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 17,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 210
-        },
-        "id": "vKKJcqx9ELz-",
-        "outputId": "d8e6ebe5-ebba-46d0-a001-49b8cfecedae"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "pH_Category\n",
-              "Basic      821\n",
-              "Acidic     795\n",
-              "Neutral    755\n",
-              "Name: count, dtype: int64"
-            ]
-          },
-          "execution_count": 17,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "def classify_ph(value):\n",
-        "  if value < 7:\n",
-        "    return \"Acidic\"\n",
-        "  elif value > 7:\n",
-        "    return \"Basic\"\n",
-        "  else:\n",
-        "    return \"Neutral\"\n",
-        "\n",
-        "df[\"pH_Category\"] = df[\"pH (standard units)\"].apply(classify_ph)\n",
-        "df[\"pH_Category\"].value_counts()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 19,
+      "execution_count": null,
       "metadata": {},
       "outputs": [
         {
@@ -435,6 +395,7 @@
             "Year                          0\n",
             "pH_Category                   0\n",
             "dtype: int64\n",
+            "Removed rows with missing pH values: 0\n",
             "\n",
             "Missing values after cleaning:\n",
             "Site_Id                       0\n",
@@ -465,16 +426,69 @@
         "print(\"Missing values before cleaning:\")\n",
         "print(df.isna().sum())\n",
         "\n",
-        "# Drop rows with missing pH values\n",
+        "#original amount of rows\n",
+        "original_rows = len(df)\n",
+        "\n",
+        "# drop rows with missing pH values\n",
         "df = df.dropna(subset=[\"pH (standard units)\"])\n",
+        "removed_rows = original_rows - len(df)\n",
+        "\n",
+        "print(\"Removed rows with missing pH values:\", removed_rows)\n",
         "\n",
         "print(\"\\nMissing values after cleaning:\")\n",
         "print(df.isna().sum())\n"
       ]
     },
     {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Missing pH values were dropped (Above) before the pH_category was created. (Below)"
+      ]
+    },
+    {
       "cell_type": "code",
-      "execution_count": 20,
+      "execution_count": 34,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 210
+        },
+        "id": "vKKJcqx9ELz-",
+        "outputId": "d8e6ebe5-ebba-46d0-a001-49b8cfecedae"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "pH_Category\n",
+              "Basic      821\n",
+              "Acidic     795\n",
+              "Neutral    660\n",
+              "Name: count, dtype: int64"
+            ]
+          },
+          "execution_count": 34,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "def classify_ph(value):\n",
+        "  if value < 7:\n",
+        "    return \"Acidic\"\n",
+        "  elif value > 7:\n",
+        "    return \"Basic\"\n",
+        "  else:\n",
+        "    return \"Neutral\"\n",
+        "\n",
+        "df[\"pH_Category\"] = df[\"pH (standard units)\"].apply(classify_ph)\n",
+        "df[\"pH_Category\"].value_counts()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 31,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -521,7 +535,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 22,
+      "execution_count": 32,
       "metadata": {},
       "outputs": [
         {


### PR DESCRIPTION
Moves the action to drop the missing pH values to a location before the pH_category was created. A markdown cell was made to clarify this change. The bar charts were re-ran to correctly show only rows with valid pH values. 

Resolves issue #2
